### PR TITLE
Add optional parameter to NB::begin(...) to set the APN to use for registration

### DIFF
--- a/src/NB.cpp
+++ b/src/NB.cpp
@@ -26,6 +26,8 @@
 enum {
   READY_STATE_SET_MINIMUM_FUNCTIONALITY_MODE,
   READY_STATE_WAIT_SET_MINIMUM_FUNCTIONALITY_MODE,
+  READY_STATE_DETACH_DATA,
+  READY_STATE_WAIT_DETACH_DATA,
   READY_STATE_CHECK_SIM,
   READY_STATE_WAIT_CHECK_SIM_RESPONSE,
   READY_STATE_UNLOCK_SIM,
@@ -148,6 +150,25 @@ int NB::ready()
     }
 
     case READY_STATE_WAIT_SET_MINIMUM_FUNCTIONALITY_MODE:{
+      if (ready > 1) {
+        _state = ERROR;
+        ready = 2;
+      } else {
+        _readyState = READY_STATE_DETACH_DATA;
+        ready = 0;
+      }
+
+      break;
+    }
+
+    case READY_STATE_DETACH_DATA: {
+      MODEM.send("AT+CGATT=0");
+      _readyState = READY_STATE_WAIT_DETACH_DATA;
+      ready = 0;
+      break;
+    }
+
+    case READY_STATE_WAIT_DETACH_DATA:{
       if (ready > 1) {
         _state = ERROR;
         ready = 2;

--- a/src/NB.h
+++ b/src/NB.h
@@ -35,6 +35,7 @@ public:
   /** Start the NB IoT modem, attaching to the NB IoT or LTE Cat M1 network
       @param pin         SIM PIN number (4 digits in a string, example: "1234"). If
                          NULL the SIM has no configured PIN.
+      @param apn         (optional) APN to use
       @param restart     Restart the modem. Default is TRUE. The modem receives
                          a signal through the Ctrl/D7 pin. If it is shut down, it will
                          start-up. If it is running, it will restart. Takes up to 10
@@ -45,6 +46,7 @@ public:
       @return If synchronous, NB_NetworkStatus_t. If asynchronous, returns 0.
     */
   NB_NetworkStatus_t begin(const char* pin = 0, bool restart = true, bool synchronous = true);
+  NB_NetworkStatus_t begin(const char* pin, const char* apn, bool restart = true, bool synchronous = true);
 
   /** Check network access status
       @return 1 if Alive, 0 if down
@@ -77,6 +79,7 @@ private:
   NB_NetworkStatus_t _state;
   int _readyState;
   const char* _pin;
+  const char* _apn;
   String _response;
   unsigned long _timeout;
 };


### PR DESCRIPTION
The APN defaults to "" if not provided.

Begin also puts the modem in minimum functionality mode at start and restores to full functionality mode after the APN is set.