### PR TITLE
Add ModemClass::debugf

### DIFF
--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -106,6 +106,21 @@ void ModemClass::noDebug()
   _debugPrint = NULL;
 }
 
+void ModemClass::debugf(const char *fmt, ...)
+{
+  if (NULL == _debugPrint)
+    return;
+
+  char buf[BUFSIZ];
+
+  va_list ap;
+  va_start((ap), (fmt));
+  vsnprintf(buf, sizeof(buf) - 1, fmt, ap);
+  va_end(ap);
+
+  _debugPrint->print(buf);
+}
+
 int ModemClass::autosense(unsigned long timeout)
 {
   for (unsigned long start = millis(); (millis() - start) < timeout;) {

--- a/src/Modem.h
+++ b/src/Modem.h
@@ -40,6 +40,7 @@ public:
   void debug();
   void debug(Print& p);
   void noDebug();
+  void debugf(const char *s, ...);
 
   int autosense(unsigned long timeout = 10000);
 

--- a/src/NB.cpp
+++ b/src/NB.cpp
@@ -66,6 +66,8 @@ NB_NetworkStatus_t NB::begin(const char* pin, bool restart, bool synchronous)
 
 NB_NetworkStatus_t NB::begin(const char* pin, const char* apn, bool restart, bool synchronous)
 {
+  MODEM.debugf("NB::begin: pin='%s', apn='%s'\n", pin, apn);
+
   if (!MODEM.begin(restart)) {
     _state = ERROR;
   } else {


### PR DESCRIPTION
Add `debugf` method to `ModemClass`, making it easier to add meaningful debug messages also to other classes, such as `NB`.  