### PR TITLE
fix compiler complaint about `strptime`

### DIFF
--- a/src/NB.cpp
+++ b/src/NB.cpp
@@ -16,7 +16,7 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
-
+#define _XOPEN_SOURCE
 #include <time.h>
 
 #include "Modem.h"


### PR DESCRIPTION
from @facchinm :
compilation fails due to
`/home/travis/Arduino/libraries/MKRGSM/src/GSM.cpp:340:7: error: 'strptime' was not declared in this scope` 
which is in fact fixed by `_XOPEN_SOURCE patch`