### PR TITLE
Retrieve the latest error from the uBlox SARA R410-02B when establishing a connection fails

### DIFF
--- a/src/NBClient.cpp
+++ b/src/NBClient.cpp
@@ -34,7 +34,8 @@ enum {
   CLIENT_STATE_CONNECT,
   CLIENT_STATE_WAIT_CONNECT_RESPONSE,
   CLIENT_STATE_CLOSE_SOCKET,
-  CLIENT_STATE_WAIT_CLOSE_SOCKET
+  CLIENT_STATE_WAIT_CLOSE_SOCKET,
+  CLIENT_STATE_RETRIEVE_ERROR
 };
 
 NBClient::NBClient(bool synch) :
@@ -172,8 +173,14 @@ int NBClient::ready()
     }
 
     case CLIENT_STATE_WAIT_CLOSE_SOCKET: {
-      _state = CLIENT_STATE_IDLE;
+      _state = CLIENT_STATE_RETRIEVE_ERROR;
       _socket = -1;
+      break;
+    }
+
+    case CLIENT_STATE_RETRIEVE_ERROR: {
+      MODEM.send("AT+USOER");
+      _state = CLIENT_STATE_IDLE;
       break;
     }
   }


### PR DESCRIPTION
AT-Log **without** this PR
```
AT+USOCR=6
+USOCR: 0
OK

AT+USOCO=0,"example.org",80
ERROR

AT+USOCL=0
OK
```
AT-Log **with** this PR
```
AT+USOCR=6
+USOCR: 0
OK

AT+USOCO=0,"example.org",80
ERROR

AT+USOCL=0
OK

AT+USOER
+USOER: 11
OK
```