### PR TITLE
fix wron nvariable name in testGPRS example

### DIFF
--- a/examples/Tools/TestGPRS/TestGPRS.ino
+++ b/examples/Tools/TestGPRS/TestGPRS.ino
@@ -112,7 +112,7 @@ void loop() {
 
       client.println(" HTTP/1.1");
       client.print("Host: ");
-      client.println(server);
+      client.println(url);
       client.println("Connection: close");
       client.println();
       Serial.println(oktext);


### PR DESCRIPTION
fix: https://github.com/arduino-libraries/MKRNB/commit/d0f061d452c1f3a6a1fc173f174237058b1db5c8#commitcomment-37640229