### PR TITLE
Removal of Extra MODEM.poll() present in nb.cpp

### DIFF
--- a/src/NB.cpp
+++ b/src/NB.cpp
@@ -152,7 +152,7 @@ int NB::ready()
     return 0;
   }
 
-  MODEM.poll();
+  //MODEM.poll();
 
   switch (_readyState) {
     case READY_STATE_SET_ERROR_DISABLED: {

--- a/src/NB.cpp
+++ b/src/NB.cpp
@@ -152,8 +152,6 @@ int NB::ready()
     return 0;
   }
 
-  //MODEM.poll();
-
   switch (_readyState) {
     case READY_STATE_SET_ERROR_DISABLED: {
       MODEM.send("AT+CMEE=0");


### PR DESCRIPTION
Hi, in NB.cpp on line 149 I find int ready = MODEM.ready();, this calls MODEM.poll() internally to update the internal state, then reads and returns the state. What is the reason for the extra MODEM.poll();on line 155?

I have commented it out in my copy of the library. The code runs fine without it, and it is not present in the parallel library for MKR 1400 GSM.

I recommend this change hope it helps :)