### PR TITLE
No SMS deadlock

### DIFF
--- a/src/NB_SMS.cpp
+++ b/src/NB_SMS.cpp
@@ -128,8 +128,9 @@ int NB_SMS::available()
 
     if (_synch) {
       unsigned long start = millis();
-      while ((r = ready()) == 0 && (millis() - start) < 3*60*1000)
+      while ((r = ready()) == 0 && (millis() - start) < 3*60*1000) {
         delay(100);
+      }
     } else {
       r = ready();
     }

--- a/src/NB_SMS.cpp
+++ b/src/NB_SMS.cpp
@@ -127,7 +127,10 @@ int NB_SMS::available()
     }
 
     if (_synch) {
-      r = MODEM.waitForResponse(3*60*1000);
+      unsigned long start = millis();
+      while ((r = ready()) == 0 && (millis() - start) < 3*60*1000)
+        delay(100);
+      }
     } else {
       r = ready();
     }

--- a/src/NB_SMS.cpp
+++ b/src/NB_SMS.cpp
@@ -130,7 +130,6 @@ int NB_SMS::available()
       unsigned long start = millis();
       while ((r = ready()) == 0 && (millis() - start) < 3*60*1000)
         delay(100);
-      }
     } else {
       r = ready();
     }

--- a/src/NB_SMS.cpp
+++ b/src/NB_SMS.cpp
@@ -94,11 +94,9 @@ int NB_SMS::endSMS()
 
   if (_smsTxActive) {
     MODEM.write(26);
-
+    
     if (_synch) {
-      while ((r = MODEM.ready()) == 0) {
-        delay(100);
-      }
+      r = MODEM.waitForResponse(3*60*1000);
     } else {
       r = MODEM.ready();
     }
@@ -129,9 +127,7 @@ int NB_SMS::available()
     }
 
     if (_synch) {
-      while ((r = ready()) == 0) {
-        delay(100);
-      }
+      r = MODEM.waitForResponse(3*60*1000);
     } else {
       r = ready();
     }

--- a/src/NB_SMS.cpp
+++ b/src/NB_SMS.cpp
@@ -94,7 +94,7 @@ int NB_SMS::endSMS()
 
   if (_smsTxActive) {
     MODEM.write(26);
-    
+
     if (_synch) {
       r = MODEM.waitForResponse(3*60*1000);
     } else {


### PR DESCRIPTION
Add timeout for endSMS() and available(), corresponding to the data sheet timeout. Without this, if the modem hangs or provides an unexpected answer, the library may hang forever. 