### PR TITLE
Remove call to listFile(filename) from deleteFile(filename)

### DIFF
--- a/src/NBFileUtils.cpp
+++ b/src/NBFileUtils.cpp
@@ -297,9 +297,6 @@ bool NBFileUtils::deleteFile(const String filename)
 {
     String response;
 
-    if (listFile(filename) == 0)
-        return false;
-
     MODEM.sendf("AT+UDELFILE=\"%s\"", filename.c_str());
     auto status = MODEM.waitForResponse(100, &response);
 


### PR DESCRIPTION
This is a work-around in case of the file to be deleted does not exist.
>The issue that I was having before was that the check was made with "listFile(filename)". This function asks the Sara for a specific file (with AT+ULSTFILE=2,"filename") but, instead of getting as a result the length of that file, I was sometimes getting the full list of the files, so what I would get with AT+ULSTFILE (and the file UPDATE.OK was there!). 