### PR TITLE
Fix power pulse & reset issue

### DIFF
--- a/examples/Tools/SerialSARAPassthrough/SerialSARAPassthrough.ino
+++ b/examples/Tools/SerialSARAPassthrough/SerialSARAPassthrough.ino
@@ -10,12 +10,11 @@
    Circuit:
    - MKR NB 1500 board
    - Antenna
-   - 1500 mAh or higher lipo battery connected
    - SIM card
 
-   Make sure the Serial Monitor's line ending is set to "Both NL and CR"
+   Make sure the Serial Monitor's line ending is set to "Both NL and CR" or "Carriage Return"
 
-   create 11 December 2017
+   created 11 December 2017
    Sandeep Mistry
 */
 
@@ -23,15 +22,15 @@
 unsigned long baud = 115200;
 
 void setup() {
-  // enable the POW_ON pin
+  // NEVER EVER use RESET_N
+  pinMode(SARA_RESETN, OUTPUT);
+  digitalWrite(SARA_RESETN, LOW);
+
+  // Send Poweron pulse
   pinMode(SARA_PWR_ON, OUTPUT);
   digitalWrite(SARA_PWR_ON, HIGH);
-
-  // reset the ublox module
-  pinMode(SARA_RESETN, OUTPUT);
-  digitalWrite(SARA_RESETN, HIGH);
-  delay(100);
-  digitalWrite(SARA_RESETN, LOW);
+  delay(150);
+  digitalWrite(SARA_PWR_ON, LOW);
 
   Serial.begin(baud);
   SerialSARA.begin(baud);

--- a/src/Modem.h
+++ b/src/Modem.h
@@ -25,6 +25,18 @@
 
 #include <Arduino.h>
 
+/* The NB 1500 does not connect the SARA V_INT pin so that it can be monitored.
+   The below constants and associated code enables connecting SARA_VINT to a digital input
+   using a level shifter (1.8V to 5V) or simply a MOS transistor, say a 2N7000. 
+   The code does rudimentary tracking of the on/off state if this is not available.
+*/ 
+#define SARA_VINT_OFF (-1)
+#define SARA_VINT_ON  (-2)
+
+#ifndef SARA_VINT
+#define SARA_VINT SARA_VINT_OFF
+#endif
+
 class ModemUrcHandler {
 public:
   virtual void handleUrc(const String& urc) = 0;
@@ -32,7 +44,7 @@ public:
 
 class ModemClass {
 public:
-  ModemClass(Uart& uart, unsigned long baud, int resetPin, int powerOnPin);
+  ModemClass(Uart& uart, unsigned long baud, int resetPin, int powerOnPin, int vIntPin=SARA_VINT);
 
   int begin(bool restart = false);
   void end();
@@ -45,6 +57,9 @@ public:
 
   int noop();
   int reset();
+  int shutdown();
+  int isPowerOn();
+  void setVIntPin(int vIntPin);
 
   size_t write(uint8_t c);
   size_t write(const uint8_t*, size_t);
@@ -69,6 +84,7 @@ private:
   unsigned long _baud;
   int _resetPin;
   int _powerOnPin;
+  int _vIntPin;
   unsigned long _lastResponseOrUrcMillis;
 
   enum {

--- a/src/NB.cpp
+++ b/src/NB.cpp
@@ -124,17 +124,17 @@ int NB::isAccessAlive()
 
 bool NB::shutdown()
 {
-  if (_state == NB_READY) {
-    MODEM.send("AT+CPWROFF");
-    MODEM.waitForResponse(40000);
+  // Attempt AT command shutdown
+  if (_state == NB_READY && MODEM.shutdown()) {
+    _state = NB_OFF;
+    return true;
   }
-  MODEM.end();
-  _state = NB_OFF;
-  return true;
+  return false;
 }
 
 bool NB::secureShutdown()
 {
+  // Hardware power off
   MODEM.end();
   _state = NB_OFF;
   return true;

--- a/src/NBFileUtils.cpp
+++ b/src/NBFileUtils.cpp
@@ -12,8 +12,7 @@ bool NBFileUtils::begin(const bool restart)
 {
     int status;
 
-    if (restart)
-        MODEM.begin();
+    MODEM.begin(restart);
 
     if (_debug) {
         MODEM.debug();


### PR DESCRIPTION
This is intended to solve the issues (#47) related to the incorrect power-on/off and reset sequences of SARA-R410M module.
The modified library has been provided by @janakelarsson.
Then, the File System has been accordingly modified: the `MODEM.begin(restart)` function is always called, but the Sara module is restarted only when needed.