### PR TITLE
Add hardReset()

### DIFF
--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -127,6 +127,15 @@ void ModemClass::end()
   }
 }
 
+void ModemClass::hardReset()
+{
+  // Hardware pin reset, only use in EMERGENCY
+  digitalWrite(_resetPin, HIGH);
+  delay(1000); // Datasheet says nothing, so guess we wait one second
+  digitalWrite(_resetPin, LOW);
+  setVIntPin(SARA_VINT_OFF);
+}
+
 void ModemClass::debug()
 {
   debug(Serial);

--- a/src/Modem.h
+++ b/src/Modem.h
@@ -58,6 +58,7 @@ public:
   int noop();
   int reset();
   int shutdown();
+  void hardReset(); // Hardware pin reset, only use in EMERGENCY
   int isPowerOn();
   void setVIntPin(int vIntPin);
 


### PR DESCRIPTION
The new begin/end avoid RESET_N, because in normal operation this should never be used since it can brick the modem. 

It is possible that the modem hangs so that AT command or power pin shutdown does not work. Even rebooting may not work, but only power cycling or using RESET_N does work. This adds a user interface for /emergency/ hard reset using RESET_N.