### PR TITLE
Allowing for detachGPRS() to break endless loop

### DIFF
--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -153,6 +153,7 @@ int GPRS::ready()
       } else {
         _state = GPRS_STATE_IDLE;
         _status = IDLE;
+        ready = 1;
       }
       break;
     }

--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -153,9 +153,7 @@ int GPRS::ready()
       } else {
         _state = GPRS_STATE_IDLE;
         _status = IDLE;
-
         ready = 1;
-
       }
       break;
     }


### PR DESCRIPTION
This is the pull request for issue #68 

It sets the value for ready to 1 to be able to leave the while-condition once the GPRS is detached.