### PR TITLE
Fix hardReset method to match the datasheet

### DIFF
--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -131,7 +131,7 @@ void ModemClass::hardReset()
 {
   // Hardware pin reset, only use in EMERGENCY
   digitalWrite(_resetPin, HIGH);
-  delay(1000); // Datasheet says nothing, so guess we wait one second
+  delay(10000); // Datasheet says 10s minimum low pulse on reset pin. 
   digitalWrite(_resetPin, LOW);
   setVIntPin(SARA_VINT_OFF);
 }


### PR DESCRIPTION
After reviewing the code for the MKRNB library, I noticed the hardReset method is still incorrect when compared to the SARA-R410M-02B datasheet.

![image](https://user-images.githubusercontent.com/8997932/102625288-3e47a980-4113-11eb-9c85-c6bdfcc82570.png)

Ref: https://www.u-blox.com/sites/default/files/SARA-R4_DataSheet_%28UBX-16024152%29.pdf