### PR TITLE
Set NB default restart value to false

### DIFF
--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -61,11 +61,6 @@ int ModemClass::begin(bool restart)
   // datasheet warns not to use _resetPin, this may lead to an unrecoverable state
   digitalWrite(_resetPin, LOW);
 
-  if (restart) {
-    shutdown();
-    end();
-  }
-
   _uart->begin(_baud > 115200 ? 115200 : _baud);
 
   // power on module
@@ -78,6 +73,14 @@ int ModemClass::begin(bool restart)
     if (!autosense()) {
       return 0;
     }
+  }
+
+  if (restart) {
+    shutdown();
+    end();
+    delay(1500);
+    setVIntPin(SARA_VINT_OFF);
+    begin(false);
   }
 
   if (!autosense()) {

--- a/src/NB.h
+++ b/src/NB.h
@@ -45,9 +45,9 @@ public:
                          to call repeatedly ready() until you get a result. Default is TRUE.
       @return If synchronous, NB_NetworkStatus_t. If asynchronous, returns 0.
     */
-  NB_NetworkStatus_t begin(const char* pin = 0, bool restart = true, bool synchronous = true);
-  NB_NetworkStatus_t begin(const char* pin, const char* apn, bool restart = true, bool synchronous = true);
-  NB_NetworkStatus_t begin(const char* pin, const char* apn, const char* username, const char* password, bool restart = true, bool synchronous = true);
+  NB_NetworkStatus_t begin(const char* pin = 0, bool restart = false, bool synchronous = true);
+  NB_NetworkStatus_t begin(const char* pin, const char* apn, bool restart = false, bool synchronous = true);
+  NB_NetworkStatus_t begin(const char* pin, const char* apn, const char* username, const char* password, bool restart = false, bool synchronous = true);
 
   /** Check network access status
       @return 1 if Alive, 0 if down


### PR DESCRIPTION
This PR is intended to fix #71.
The modem used to behave properly only when using `nbAccess.begin(PINNUMBER, APN, USERNAME, PASSWORD, false, true)`, which does not restart the modem.
By changing in the library the default value of `restart` from true to false, the modem behaves correctly without specifying the last two input parameters: `nbAccess.begin(PINNUMBER, APN, USERNAME, PASSWORD)`.