### PR TITLE
Enlarge the chunkSize

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ The Cpt. Holzschnauz extension makes it possible to use the internal MQTT functi
 MQTT without external mqtt libraries, tcp socket headaches etc. Easy & convenient! Let the modem do the sh..!
 
 
-Check the example.
+UNDER CONSTRUCTION!! BETA! NOT FINISHED! CONTRIBUTE IF YOU CAN! Check the example.
 
 Done:
 Constructor: Example: NBMqtt mqtt;

--- a/README.adoc
+++ b/README.adoc
@@ -18,17 +18,17 @@ UNDER CONSTRUCTION!! BETA! NOT FINISHED! CONTRIBUTE IF YOU CAN! Check the exampl
 Done:
 Constructor: Example: NBMqtt mqtt;
 
-getMQTTerror Get the last MQTT error from the modem.Example : mqtt.getMQTTerror();  
+getMQTTerror Get the last MQTT error from the modem.Example: mqtt.getMQTTerror();  
 
-setMQTTClientID  Set the MQTT client ID : Use your SIM IMEI. Example mqtt.setMQTTClientID("352753090834234");  
+setMQTTClientID  Set the MQTT client ID : Use your SIM IMEI. Example: mqtt.setMQTTClientID("352753090834234");  
 
-setMQTTPort(Int): Set the MQTT Port (Normal is 1883, SSL is 8883(not yet implemented). Example :  mqtt.setMQTTPort(1883);  
+setMQTTPort(Int): Set the MQTT Port (Normal is 1883, SSL is 8883(not yet implemented). Example:  mqtt.setMQTTPort(1883);  
 
 setMQTTUserPassword(String, String): Set Username / Password for the MQTT broker. Example: mqtt.setMQTTUserPassword("username", "password");  
 
 setMQTTbrokerURL(String): Set the MQTT broker URL (DNS is made automatic). Example: mqtt.setMQTTBrokerURL("public.cloud.shiftr.io");   
 
-setMQTTbrokerIP(String): Set the MQTT broker IP (not necessary in general, provide a broker URL!)  
+setMQTTbrokerIP(String): Set the MQTT broker IP (not necessary in general, provide a broker URL!) Example: setMQTTbrokerIP(84.15.13.144);
 
 setMQTTBrokerConnect(bool): Connect / Disconnect to the MQTT broker. Example: mqtt.setMQTTBrokerConnect(true); to connect, mqtt.setMQTTBrokerConnect(false); to disconnect  
 
@@ -47,8 +47,6 @@ Set last will
 Save/restore settings to NV memory
   
 
-For more information about this library please visit us at
-https://www.arduino.cc/en/Reference/{repository-name}
 
 == License ==
 

--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,7 @@ image:https://github.com/{repository-owner}/{repository-name}/workflows/Spell%20
 This library enables an Arduino MKR NB 1500 board to connect to the internet over a NarrowBand IoT or LTE Cat M1 network.
 The Cpt. Holzschnauz extension makes it possible to use the internal MQTT functionality of the SARA R410 modem for convenient MQTT.
 
+MQTT without external mqtt libraries, tcp socket headaches etc. Easy & convenient! Let the modem do the sh..!
 
 
 Check the example.

--- a/README.adoc
+++ b/README.adoc
@@ -8,12 +8,12 @@
 This library enables an Arduino MKR NB 1500 board to connect to the internet over a NarrowBand IoT or LTE Cat M1 network.
 The Cpt. Holzschnauz extension makes it possible to use the internal MQTT functionality of the SARA R410 modem for convenient MQTT.
 
-MQTT without external mqtt libraries, tcp socket headaches etc. 
-
-Easy & convenient! Let the modem do the sh..!
+MQTT without external mqtt libraries, tcp socket headaches etc. Easy & convenient! Let the modem do the sh..!
 
 
 UNDER CONSTRUCTION!! BETA! NOT FINISHED! CONTRIBUTE IF YOU CAN! Check the example.
+
+
 
 Done:
 Constructor: Example: NBMqtt mqtt;

--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,9 @@
 This library enables an Arduino MKR NB 1500 board to connect to the internet over a NarrowBand IoT or LTE Cat M1 network.
 The Cpt. Holzschnauz extension makes it possible to use the internal MQTT functionality of the SARA R410 modem for convenient MQTT.
 
-MQTT without external mqtt libraries, tcp socket headaches etc. Easy & convenient! Let the modem do the sh..!
+MQTT without external mqtt libraries, tcp socket headaches etc. 
+
+Easy & convenient! Let the modem do the sh..!
 
 
 UNDER CONSTRUCTION!! BETA! NOT FINISHED! CONTRIBUTE IF YOU CAN! Check the example.

--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,8 @@ The Cpt. Holzschnauz extension makes it possible to use the internal MQTT stack 
 Check the example.
 
 Done:
-Constructor: Example: NBMqtt mqtt;  
+Constructor: Example: NBMqtt mqtt;
+
 getMQTTerror Get the last MQTT error from the modem.Example : mqtt.getMQTTerror();  
 setMQTTClientID  Set the MQTT client ID : Use your SIM IMEI. Example mqtt.setMQTTClientID("352753090834234");  
 setMQTTPort(Int): Set the MQTT Port (Normal is 1883, SSL is 8883(not yet implemented). Example :  mqtt.setMQTTPort(1883);  

--- a/README.adoc
+++ b/README.adoc
@@ -4,8 +4,6 @@
 
 = {repository-name} Library for Arduino =
 
-image:https://github.com/{repository-owner}/{repository-name}/workflows/Compile%20Examples/badge.svg["Compile Examples Status", link="https://github.com/{repository-owner}/{repository-name}/actions?workflow=Compile+Examples"]
-image:https://github.com/{repository-owner}/{repository-name}/workflows/Spell%20Check/badge.svg["Spell Check Status", link="https://github.com/{repository-owner}/{repository-name}/actions?workflow=Spell+Check"]
 
 This library enables an Arduino MKR NB 1500 board to connect to the internet over a NarrowBand IoT or LTE Cat M1 network.
 The Cpt. Holzschnauz extension makes it possible to use the internal MQTT functionality of the SARA R410 modem for convenient MQTT.

--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,10 @@ image:https://github.com/{repository-owner}/{repository-name}/workflows/Compile%
 image:https://github.com/{repository-owner}/{repository-name}/workflows/Spell%20Check/badge.svg["Spell Check Status", link="https://github.com/{repository-owner}/{repository-name}/actions?workflow=Spell+Check"]
 
 This library enables an Arduino MKR NB 1500 board to connect to the internet over a NarrowBand IoT or LTE Cat M1 network.
-The Cpt. Holzschnauz extension makes it possible to use the internal MQTT stack of the SARA R410 modem for convenient MQTT:
+The Cpt. Holzschnauz extension makes it possible to use the internal MQTT functionality of the SARA R410 modem for convenient MQTT.
+
+
+
 Check the example.
 
 Done:

--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,7 @@ Set Timeouts
 
 Set last will  
 
-Save/restore settings  
+Save/restore settings to NV memory
   
 
 For more information about this library please visit us at

--- a/README.adoc
+++ b/README.adoc
@@ -1,13 +1,14 @@
 // Define the repository information in these attributes
 :repository-owner: arduino-libraries
-:repository-name: MKRNB
+:repository-name: MKRNB SARA R410 MQTT Extension
 
 = {repository-name} Library for Arduino =
 
 image:https://github.com/{repository-owner}/{repository-name}/workflows/Compile%20Examples/badge.svg["Compile Examples Status", link="https://github.com/{repository-owner}/{repository-name}/actions?workflow=Compile+Examples"]
 image:https://github.com/{repository-owner}/{repository-name}/workflows/Spell%20Check/badge.svg["Spell Check Status", link="https://github.com/{repository-owner}/{repository-name}/actions?workflow=Spell+Check"]
 
-This library enables an Arduino MKR NB 1500 board to connect to the internet over a NarrowBand IoT or LTE Cat M1 network. 
+This library enables an Arduino MKR NB 1500 board to connect to the internet over a NarrowBand IoT or LTE Cat M1 network.
+The Cpt. Holzschnauz extension makes it possible to use the internal MQTT stack of the SARA R410 modem for convenient MQTT
 
 For more information about this library please visit us at
 https://www.arduino.cc/en/Reference/{repository-name}

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 // Define the repository information in these attributes
 :repository-owner: arduino-libraries
-:repository-name: MKRNB SARA R410 MQTT Extension
+:repository-name: MKRNB SARA R410 MQTT Extension 0.1
 
 = {repository-name} Library for Arduino =
 
@@ -8,7 +8,26 @@ image:https://github.com/{repository-owner}/{repository-name}/workflows/Compile%
 image:https://github.com/{repository-owner}/{repository-name}/workflows/Spell%20Check/badge.svg["Spell Check Status", link="https://github.com/{repository-owner}/{repository-name}/actions?workflow=Spell+Check"]
 
 This library enables an Arduino MKR NB 1500 board to connect to the internet over a NarrowBand IoT or LTE Cat M1 network.
-The Cpt. Holzschnauz extension makes it possible to use the internal MQTT stack of the SARA R410 modem for convenient MQTT
+The Cpt. Holzschnauz extension makes it possible to use the internal MQTT stack of the SARA R410 modem for convenient MQTT:
+Check the example.
+
+Done:
+Constructor: Example: NBMqtt mqtt;
+getMQTTerror Get the last MQTT error from the modem.Example : mqtt.getMQTTerror();
+setMQTTClientID  Set the MQTT client ID : Use your SIM IMEI. Example mqtt.setMQTTClientID("352753090834234");
+setMQTTPort(Int): Set the MQTT Port (Normal is 1883, SSL is 8883(not yet implemented). Example :  mqtt.setMQTTPort(1883);
+setMQTTUserPassword(String, String): Set Username / Password for the MQTT broker. Example: mqtt.setMQTTUserPassword("username", "password"); 
+setMQTTbrokerURL(String): Set the MQTT broker URL (DNS is made automatic). Example: mqtt.setMQTTBrokerURL("public.cloud.shiftr.io"); 
+setMQTTbrokerIP(String): Set the MQTT broker IP (not necessary in general, provide a broker URL!)
+setMQTTBrokerConnect(bool): Connect / Disconnect to the MQTT broker. Example: mqtt.setMQTTBrokerConnect(true); to connect, mqtt.setMQTTBrokerConnect(false); to disconnect
+sendMQTTMsg(String, String): Send a MQTT message to a topic. Example: mqtt.sendMQTTMsg("/TestTopic", "TestMessage");
+setMQTTSubscribe(String): Subscribe to a topic. Example: setMQTTSubscribe("TestTopic");
+To do:
+Read out MQTT messages
+Set Timeouts
+Set last will
+Save/restore settings
+
 
 For more information about this library please visit us at
 https://www.arduino.cc/en/Reference/{repository-name}

--- a/README.adoc
+++ b/README.adoc
@@ -12,22 +12,23 @@ The Cpt. Holzschnauz extension makes it possible to use the internal MQTT stack 
 Check the example.
 
 Done:
-Constructor: Example: NBMqtt mqtt;
-getMQTTerror Get the last MQTT error from the modem.Example : mqtt.getMQTTerror();
-setMQTTClientID  Set the MQTT client ID : Use your SIM IMEI. Example mqtt.setMQTTClientID("352753090834234");
-setMQTTPort(Int): Set the MQTT Port (Normal is 1883, SSL is 8883(not yet implemented). Example :  mqtt.setMQTTPort(1883);
-setMQTTUserPassword(String, String): Set Username / Password for the MQTT broker. Example: mqtt.setMQTTUserPassword("username", "password"); 
-setMQTTbrokerURL(String): Set the MQTT broker URL (DNS is made automatic). Example: mqtt.setMQTTBrokerURL("public.cloud.shiftr.io"); 
-setMQTTbrokerIP(String): Set the MQTT broker IP (not necessary in general, provide a broker URL!)
-setMQTTBrokerConnect(bool): Connect / Disconnect to the MQTT broker. Example: mqtt.setMQTTBrokerConnect(true); to connect, mqtt.setMQTTBrokerConnect(false); to disconnect
-sendMQTTMsg(String, String): Send a MQTT message to a topic. Example: mqtt.sendMQTTMsg("/TestTopic", "TestMessage");
-setMQTTSubscribe(String): Subscribe to a topic. Example: setMQTTSubscribe("TestTopic");
-To do:
-Read out MQTT messages
-Set Timeouts
-Set last will
-Save/restore settings
+Constructor: Example: NBMqtt mqtt;  
+getMQTTerror Get the last MQTT error from the modem.Example : mqtt.getMQTTerror();  
+setMQTTClientID  Set the MQTT client ID : Use your SIM IMEI. Example mqtt.setMQTTClientID("352753090834234");  
+setMQTTPort(Int): Set the MQTT Port (Normal is 1883, SSL is 8883(not yet implemented). Example :  mqtt.setMQTTPort(1883);  
+setMQTTUserPassword(String, String): Set Username / Password for the MQTT broker. Example: mqtt.setMQTTUserPassword("username", "password");   
+setMQTTbrokerURL(String): Set the MQTT broker URL (DNS is made automatic). Example: mqtt.setMQTTBrokerURL("public.cloud.shiftr.io");   
+setMQTTbrokerIP(String): Set the MQTT broker IP (not necessary in general, provide a broker URL!)  
+setMQTTBrokerConnect(bool): Connect / Disconnect to the MQTT broker. Example: mqtt.setMQTTBrokerConnect(true); to connect, mqtt.setMQTTBrokerConnect(false); to disconnect  
+sendMQTTMsg(String, String): Send a MQTT message to a topic. Example: mqtt.sendMQTTMsg("/TestTopic", "TestMessage");  
+setMQTTSubscribe(String): Subscribe to a topic. Example: setMQTTSubscribe("TestTopic");  
 
+To do:  
+Read out MQTT messages  
+Set Timeouts  
+Set last will  
+Save/restore settings  
+  
 
 For more information about this library please visit us at
 https://www.arduino.cc/en/Reference/{repository-name}

--- a/README.adoc
+++ b/README.adoc
@@ -15,19 +15,31 @@ Done:
 Constructor: Example: NBMqtt mqtt;
 
 getMQTTerror Get the last MQTT error from the modem.Example : mqtt.getMQTTerror();  
+
 setMQTTClientID  Set the MQTT client ID : Use your SIM IMEI. Example mqtt.setMQTTClientID("352753090834234");  
+
 setMQTTPort(Int): Set the MQTT Port (Normal is 1883, SSL is 8883(not yet implemented). Example :  mqtt.setMQTTPort(1883);  
-setMQTTUserPassword(String, String): Set Username / Password for the MQTT broker. Example: mqtt.setMQTTUserPassword("username", "password");   
+
+setMQTTUserPassword(String, String): Set Username / Password for the MQTT broker. Example: mqtt.setMQTTUserPassword("username", "password");  
+
 setMQTTbrokerURL(String): Set the MQTT broker URL (DNS is made automatic). Example: mqtt.setMQTTBrokerURL("public.cloud.shiftr.io");   
+
 setMQTTbrokerIP(String): Set the MQTT broker IP (not necessary in general, provide a broker URL!)  
+
 setMQTTBrokerConnect(bool): Connect / Disconnect to the MQTT broker. Example: mqtt.setMQTTBrokerConnect(true); to connect, mqtt.setMQTTBrokerConnect(false); to disconnect  
+
 sendMQTTMsg(String, String): Send a MQTT message to a topic. Example: mqtt.sendMQTTMsg("/TestTopic", "TestMessage");  
+
 setMQTTSubscribe(String): Subscribe to a topic. Example: setMQTTSubscribe("TestTopic");  
 
 To do:  
+
 Read out MQTT messages  
+
 Set Timeouts  
+
 Set last will  
+
 Save/restore settings  
   
 

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ getMQTTerror Get the last MQTT error from the modem.Example: mqtt.getMQTTerror()
 
 setMQTTClientID  Set the MQTT client ID : Use your SIM IMEI. Example: mqtt.setMQTTClientID("352753090834234");  
 
-setMQTTPort(Int): Set the MQTT Port (Normal is 1883, SSL is 8883(not yet implemented). Example:  mqtt.setMQTTPort(1883);  
+setMQTTPort(Int): Set the MQTT Port (Normaly not enrcypted is 1883, SSL is 8883. Example:  mqtt.setMQTTPort(1883);  
 
 setMQTTUserPassword(String, String): Set Username / Password for the MQTT broker. Example: mqtt.setMQTTUserPassword("username", "password");  
 
@@ -45,8 +45,8 @@ Set Timeouts
 Set last will  
 
 Save/restore settings to NV memory
-  
 
+SSL
 
 == License ==
 

--- a/examples/SARA_NBMQTT_Example.ino
+++ b/examples/SARA_NBMQTT_Example.ino
@@ -1,0 +1,92 @@
+/*
+  MQTT Client class extension for the MKRNB lib. Use the internal MQTT stack of the SARA R410 modem to do MQTT without a library, creating sockets etc. Easy & convenient!
+
+  This sketch, for the MKR NB 1500 board, setup a MQTT connection and send a MQTT Message 
+  Circuit:
+   MKR NB 1500 board
+   Antenna
+   SIM card 
+   
+  created August 4th 2021
+  Version 0.1 by Roman Bolt
+
+Done:
+
+Constructor: Example: NBMqtt mqtt;
+
+getMQTTerror Get the last MQTT error from the modem.Example : mqtt.getMQTTerror();
+setMQTTClientID  Set the MQTT client ID : Use your SIM IMEI. Example mqtt.setMQTTClientID("352753090834234");
+setMQTTPort(Int): Set the MQTT Port (Normal is 1883, SSL is 8883(not yet implemented). Example :  mqtt.setMQTTPort(1883);
+setMQTTUserPassword(String, String): Set Username / Password for the MQTT broker. Example: mqtt.setMQTTUserPassword("username", "password"); 
+setMQTTbrokerURL(String): Set the MQTT broker URL (DNS is made automatic). Example: mqtt.setMQTTBrokerURL("public.cloud.shiftr.io"); 
+setMQTTbrokerIP(String): Set the MQTT broker IP (not necessary in general, provide a broker URL!)
+setMQTTBrokerConnect(bool): Connect / Disconnect to the MQTT broker. Example: mqtt.setMQTTBrokerConnect(true); to connect, mqtt.setMQTTBrokerConnect(false); to disconnect
+sendMQTTMsg(String, String): Send a MQTT message to a topic. Example: mqtt.sendMQTTMsg("/TestTopic", "TestMessage");
+setMQTTSubscribe(String): Subscribe to a topic. Example: setMQTTSubscribe("TestTopic");
+
+To do:
+
+Read out MQTT messages
+Set Timeouts
+Set last will
+Save/restore settings
+  
+*/
+
+// include the NB library
+#include <MKRNB.h>
+
+// Please enter your sensitive data in the Secret tab or arduino_secrets.h
+// PIN Number
+const char PINNUMBER[] = "";
+
+// initialize the library instances
+NB nbAccess(true);
+NBScanner scannerNetworks;
+NBMqtt mqtt;
+
+void setup() {
+  // initialize serial communications and wait for port to open:
+  Serial.begin(115200);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  Serial.println("SARA MQTT Test");
+
+  // connection state
+  bool connected = false;
+
+  // Start GSM connection
+  
+  while (!connected) {
+    if (nbAccess.begin(PINNUMBER) == NB_READY) {
+      connected = true;
+    } else {
+      Serial.println("Not connected");
+      delay(1000);
+    }
+  }
+
+  Serial.println("NB initialized");
+
+  mqtt.setMQTTClientID("352753090834234"); // Set Client ID : USE your SIM's UMEI
+  mqtt.setMQTTPort(1883);//Set mqtt Port
+  mqtt.setMQTTBrokerURL("public.cloud.shiftr.io"); 
+  mqtt.setMQTTUserPassword("public", "public"); // User, Password
+  mqtt.setMQTTBrokerConnect(true);
+  
+}
+
+void loop() {
+
+mqtt.sendMQTTMsg("/TestTopic", "TestMessage");
+
+String mqtt_error = mqtt.getMQTTerror();
+Serial.print("MQTT Error (See page 408 of the u-blox AT Manual): ");
+Serial.println(mqtt_error);
+
+delay(5000);
+Serial.println("Done");
+
+}

--- a/examples/SARA_NBMQTT_Example.ino
+++ b/examples/SARA_NBMQTT_Example.ino
@@ -81,7 +81,10 @@ void setup() {
 void loop() {
 
 mqtt.sendMQTTMsg("/TestTopic", "TestMessage");
-
+// A little hint: If you want to construct the MQTT message out of Strings and other variables, use: 
+// char* mqtt_msg = foo bar etc.
+// mqtt.sendMQTTMsg("/TestTopic", mqtt_msg);  
+  
 String mqtt_error = mqtt.getMQTTerror();
 Serial.print("MQTT Error (See page 408 of the u-blox AT Manual): ");
 Serial.println(mqtt_error);

--- a/keywords.txt
+++ b/keywords.txt
@@ -46,6 +46,15 @@ hostByName	KEYWORD2
 getTime	KEYWORD2
 setTime	KEYWORD2
 getLocalTime	KEYWORD2
+getMQTTerror KEYWORD2
+setMQTTClientID KEYWORD2
+setMQTTPort KEYWORD2
+setMQTTUserPassword KEYWORD2
+setMQTTbrokerURL KEYWORD2
+setMQTTbrokerIP KEYWORD2
+setMQTTBrokerConnect KEYWORD2
+sendMQTTMsg KEYWORD2
+setMQTTSubscribe KEYWORD2
 
 #######################################
 # Constants

--- a/src/MKRNB.h
+++ b/src/MKRNB.h
@@ -32,5 +32,5 @@
 #include "NBUdp.h"
 
 #include "NBFileUtils.h"
-
+#include "NBMqtt.h"
 #endif

--- a/src/NBClient.cpp
+++ b/src/NBClient.cpp
@@ -290,8 +290,8 @@ size_t NBClient::write(const uint8_t* buf, size_t size)
   while (size) {
     size_t chunkSize = size;
 
-    if (chunkSize > 256) {
-      chunkSize = 256;
+    if (chunkSize > 512) {
+      chunkSize = 512;
     }
 
     command.reserve(19 + chunkSize * 2);

--- a/src/NBClient.cpp
+++ b/src/NBClient.cpp
@@ -285,7 +285,7 @@ size_t NBClient::write(const uint8_t* buf, size_t size)
   size_t written = 0;
   String command;
 
-  command.reserve(19 + (size > 256 ? 256 : size) * 2);
+  command.reserve(19 + (size > 512 ? 512 : size) * 2);
 
   while (size) {
     size_t chunkSize = size;

--- a/src/NBMqtt.cpp
+++ b/src/NBMqtt.cpp
@@ -1,0 +1,98 @@
+/*
+TO DO
+AT+UMQTT 0
+AT+UMQTT 1
+AT+UMQTT 2
+
+AT+UMQTT 4
+AT+UMQTTC=1
+AT+UMQTTC=2
+
+
+*/
+#include "Modem.h"
+
+#include "NBMqtt.h"
+
+NBMqtt::NBMqtt(bool trace)
+{
+  if (trace)
+  {
+    MODEM.debug();
+  }
+}
+
+String NBMqtt::getMQTTerror()
+{
+  String response;
+
+  MODEM.send("AT+UMQTTER");
+  if (MODEM.waitForResponse(1000, &response) == 1)
+  {
+    int firstSpaceIndex = response.indexOf(' ');
+    int lastCommaIndex = response.lastIndexOf(',');
+
+    if (firstSpaceIndex != -1 && lastCommaIndex != -1)
+    {
+      return response.substring(firstSpaceIndex + 1, lastCommaIndex);
+    }
+  }
+
+  return "";
+}
+
+String NBMqtt::setMQTTClientID(char *mqttID)
+{
+  MODEM.sendf("AT+UMQTT=0,\"%s\"", mqttID);
+  MODEM.waitForResponse(10000);
+  return "";
+}
+
+int NBMqtt::setMQTTPort(int mqttPort)
+{
+  MODEM.sendf("AT+UMQTT=1,%d", mqttPort);
+  MODEM.waitForResponse(10000);
+  return 0;
+}
+
+String NBMqtt::setMQTTUserPassword(char *mqttUser, char *mqttPW)
+{
+  MODEM.sendf("AT+UMQTT=4,\"%s\",\"%s\"", mqttUser, mqttPW);
+  MODEM.waitForResponse(10000);
+  return "";
+}
+
+String NBMqtt::setMQTTBrokerURL(char *brokerURL)
+{
+  MODEM.sendf("AT+UMQTT=2,\"%s\"", brokerURL);
+  MODEM.waitForResponse(10000);
+  return "";
+}
+
+String NBMqtt::setMQTTBrokerIP(char *brokerIP)
+{
+  MODEM.sendf("AT+UMQTT=3,\"%s\"", brokerIP);
+  MODEM.waitForResponse(10000);
+  return "";
+}
+
+bool NBMqtt::setMQTTBrokerConnect(bool con)
+{
+  MODEM.sendf("AT+UMQTTC=%d\n", con);
+  MODEM.waitForResponse(10000);
+  return "";
+}
+
+String NBMqtt::sendMQTTMsg(char *mqttTopic, char *mqttMsg)
+{
+  MODEM.sendf("AT+UMQTT=2,0,0,\"%s\",\"%s\"", mqttTopic, mqttMsg);
+  MODEM.waitForResponse(10000);
+  return "";
+}
+
+String NBMqtt::setMQTTSubscribe(char *sub_topic)
+{
+  MODEM.sendf("AT+UMQTTC=4,0,\"%s\"", sub_topic);
+  MODEM.waitForResponse(10000);
+  return "";
+}

--- a/src/NBMqtt.cpp
+++ b/src/NBMqtt.cpp
@@ -85,7 +85,7 @@ bool NBMqtt::setMQTTBrokerConnect(bool con)
 
 String NBMqtt::sendMQTTMsg(char *mqttTopic, char *mqttMsg)
 {
-  MODEM.sendf("AT+UMQTT=2,0,0,\"%s\",\"%s\"", mqttTopic, mqttMsg);
+  MODEM.sendf("AT+UMQTTC=2,0,0,\"%s\",\"%s\"", mqttTopic, mqttMsg);
   MODEM.waitForResponse(10000);
   return "";
 }

--- a/src/NBMqtt.cpp
+++ b/src/NBMqtt.cpp
@@ -78,7 +78,6 @@ String NBMqtt::setMQTTBrokerIP(char *brokerIP)
 
 bool NBMqtt::setMQTTBrokerConnect(bool con)
 {
-  //MODEM.sendf("AT+UMQTTC=%d\n", con);
   if (con == true)
   {MODEM.sendf("AT+UMQTTC=1");}
   if (con == false)

--- a/src/NBMqtt.cpp
+++ b/src/NBMqtt.cpp
@@ -78,7 +78,12 @@ String NBMqtt::setMQTTBrokerIP(char *brokerIP)
 
 bool NBMqtt::setMQTTBrokerConnect(bool con)
 {
-  MODEM.sendf("AT+UMQTTC=%d\n", con);
+  //MODEM.sendf("AT+UMQTTC=%d\n", con);
+  if (con == true)
+  {MODEM.sendf("AT+UMQTTC=1");}
+  if (con == false)
+    {MODEM.sendf("AT+UMQTTC=0");}
+  
   MODEM.waitForResponse(10000);
   return "";
 }

--- a/src/NBMqtt.h
+++ b/src/NBMqtt.h
@@ -30,7 +30,7 @@ public:
    */
   int setMQTTPort(int mqttPort);
 
-  /** Set MQTT Username Pasword
+  /** Set MQTT Username Password
       @return -
    */
   String setMQTTUserPassword(char *mqttUser, char *mqttPW);

--- a/src/NBMqtt.h
+++ b/src/NBMqtt.h
@@ -1,0 +1,65 @@
+
+
+#ifndef _NB_MQTT_H_INCLUDED
+#define _NB_MQTT_H_INCLUDED
+
+#include "NB.h"
+
+class NBMqtt
+{
+
+public:
+  /** Constructor
+      @param trace    if true, dumps all AT dialogue to Serial
+      @return - 
+  */
+  NBMqtt(bool trace = false);
+
+  /** Obtain MQTT Error
+      @return MQTT Error
+   */
+  String getMQTTerror();
+
+  /** Set MQTT ClientID
+      @return -
+   */
+  String setMQTTClientID(char *mqttID);
+
+  /** Set MQTT Port Number
+      @return -
+   */
+  int setMQTTPort(int mqttPort);
+
+  /** Set MQTT Username Pasword
+      @return -
+   */
+  String setMQTTUserPassword(char *mqttUser, char *mqttPW);
+
+  /** Set MQTT Broker URL
+      @return -
+   */
+  String setMQTTBrokerURL(char *brokerURL);
+
+  /** Set MQTT Broker IP
+      @return -
+   */
+  String setMQTTBrokerIP(char *brokerIP);
+
+ /** Connect / Disconnect MQTT Broker
+      @return -
+   */
+  bool setMQTTBrokerConnect(bool con);
+
+   /** Send a MQTT Message
+      @return -
+   */
+  String sendMQTTMsg(char *mqttTopic, char *mqttMsg);
+
+/** Subscribe to a Topic
+      @return -
+   */
+  String setMQTTSubscribe(char *sub_topic);
+
+};
+
+#endif


### PR DESCRIPTION
My problem: Because the chunkSize is limited to 256, the lib writes two times into the socket when the MQTT message is larger which causes problems with my mqtt broker.
The modem is capable to handle more, see:
AT+USOWR=?
 +USOWR: (0-6),(0-512),"HEX data"
 +USOWR: (0-6),(0-1024),"data"

So i suggest to enlarge the chunkSize at least up to 512 to write more data into the socket in one step. 
This should improve the performance for all users because of less overhead data and less AT commands to the modem.

This lib is more or less a copy of MKRGSM and needs some fine tuning for the SARA modem.

Dear coding cracks, please put some love in this very important lib!
