### PR TITLE
Push 512 instead of 256 bytes, async socket close

### DIFF
--- a/src/NBClient.cpp
+++ b/src/NBClient.cpp
@@ -165,7 +165,7 @@ int NBClient::ready()
 
     case CLIENT_STATE_CLOSE_SOCKET: {
 
-      MODEM.sendf("AT+USOCL=%d", _socket);
+      MODEM.sendf("AT+USOCL=%d,1", _socket);
 
       _state = CLIENT_STATE_WAIT_CLOSE_SOCKET;
       ready = 0;
@@ -285,13 +285,13 @@ size_t NBClient::write(const uint8_t* buf, size_t size)
   size_t written = 0;
   String command;
 
-  command.reserve(19 + (size > 256 ? 256 : size) * 2);
+  command.reserve(19 + (size > 512 ? 512 : size) * 2);
 
   while (size) {
     size_t chunkSize = size;
 
-    if (chunkSize > 256) {
-      chunkSize = 256;
+    if (chunkSize > 512) {
+      chunkSize = 512;
     }
 
     command.reserve(19 + chunkSize * 2);
@@ -436,7 +436,7 @@ void NBClient::stop()
     return;
   }
 
-  MODEM.sendf("AT+USOCL=%d", _socket);
+  MODEM.sendf("AT+USOCL=%d,1", _socket);
   MODEM.waitForResponse(10000);
 
   NBSocketBuffer.close(_socket);


### PR DESCRIPTION
1. The modem is capable to digest 512 bytes per bite to write into a tcp socket. It runs more stable like this, i think the modem expects a full load.
2. From the ublox docs to the new firmware: The +USORD AT command fails to read pending bytes when the socket is in closed state. To avoid the AT command interface hanging, it is recommended to use async socket close, e.g. AT+USOCL=0,1 (the +UUSOCL URC response will take 120 s in thiscase but will not block the AT interface).
So closing a socket with ,1 (in async mode) will not block the AT interface until the socket is closed
