### PR TITLE
Async socket close

### DIFF
--- a/src/NBUdp.cpp
+++ b/src/NBUdp.cpp
@@ -68,7 +68,7 @@ void NBUDP::stop()
     return;
   }
 
-  MODEM.sendf("AT+USOCL=%d", _socket);
+  MODEM.sendf("AT+USOCL=%d,1", _socket);
   MODEM.waitForResponse(10000);
 
   _socket = -1;


### PR DESCRIPTION
From the ublox docs: The +USORD AT command fails to read pending bytes when the socket is in closed state. To avoid the AT command interface hanging, it is recommended to use async socket close, e.g. AT+USOCL=0,1 (the +UUSOCL URC response will take 120 s in this  case but will not block the AT interface).   So closing a socket with ,1 (in async mode) will not block the AT interface until the socket is closed