### PR TITLE
Delay of 60 ms in USOWR command sequence

### DIFF
--- a/src/NBClient.cpp
+++ b/src/NBClient.cpp
@@ -300,7 +300,9 @@ size_t NBClient::write(const uint8_t* buf, size_t size)
     command += _socket;
     command += ",";
     command += chunkSize;
-    command += ",\"";
+    MODEM.send(command);
+    delay(60);
+    command = "";
 
     for (size_t i = 0; i < chunkSize; i++) {
       byte b = buf[i + written];
@@ -311,8 +313,6 @@ size_t NBClient::write(const uint8_t* buf, size_t size)
       command += (char)(n1 > 9 ? 'A' + n1 - 10 : '0' + n1);
       command += (char)(n2 > 9 ? 'A' + n2 - 10 : '0' + n2);
     }
-
-    command += "\"";
 
     MODEM.send(command);
     if (_writeSync) {


### PR DESCRIPTION
From the UBlox AT Commands example App note:

Request to write 100 data bytes into socket #0. Wait for "@" symbol indicating the data prompt is now open (AT commands are not allowed in data prompt).
After the @ prompt reception, wait for a minimum of 50 ms before sending data.

At the moment, there is no wait in the lib. I added a patch that sends the USOWR command and then wait blindly for 60 ms. I experienced troubles while waiting for the '@' prompt, so i just added a stupid delay(60) to fullfill the specs better than now. It's just a patch that can be certainly done better...