### PR TITLE
Fix bug in SMS::peek(), and allow for multiple CIDs in GPRS::ready()

### DIFF
--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -127,7 +127,7 @@ int GPRS::ready()
         _state = GPRS_STATE_IDLE;
         _status = ERROR;
       } else {
-        if (_response.endsWith("1,1")) {
+          if (_response.indexOf("1,1") >= 0) {
           _state = GPRS_STATE_IDLE;
           _status = GPRS_READY;
           ready = 1;

--- a/src/NB_SMS.cpp
+++ b/src/NB_SMS.cpp
@@ -394,7 +394,7 @@ int NB_SMS::peek()
     return *_ptrUTF8;
   }
   if (_smsDataIndex < (signed)_incomingBuffer.length() && _smsDataIndex <= _smsDataEndIndex) {
-    char c = _incomingBuffer[_smsDataIndex++];
+    char c = _incomingBuffer[_smsDataIndex+1];
     if (_charset == SMS_CHARSET_GSM
         && (c >= 0x80 || c <= 0x24 || (c&0x1F) == 0 || (c&0x1F) >= 0x1B)) {
       for (auto &gsmchar : _gsmUTF8map) {


### PR DESCRIPTION
In NB_SMS::peek() the incoming SMS message pointer would be incremented, clipping off the first letter of the incoming message. I found and fixed this issue.

In GPRS::ready() was not designed to handle multiple CIDs when connecting to GPRS. Firmware updates to the SARA-R4 allow support for multiple CIDs, and this library would hang when connecting if multiple CIDs were reported from AT+CGACT. I fixed this issue.