### PR TITLE
Changed response wait time from 10 000 to 120 000

### DIFF
--- a/src/NBClient.cpp
+++ b/src/NBClient.cpp
@@ -317,7 +317,8 @@ size_t NBClient::write(const uint8_t* buf, size_t size)
     MODEM.send(command);
     if (_writeSync) {
       String response;
-      int status = MODEM.waitForResponse(10000, &response);
+      int status = 
+        ForResponse(120000, &response);
       if ( status != 1) {
         if (status == 4 && response.indexOf("Operation not allowed") != -1 ) {
           stop();
@@ -437,7 +438,7 @@ void NBClient::stop()
   }
 
   MODEM.sendf("AT+USOCL=%d", _socket);
-  MODEM.waitForResponse(10000);
+  MODEM.waitForResponse(120000);
 
   NBSocketBuffer.close(_socket);
 


### PR DESCRIPTION
Documentation specifies that the wait response timer could be as high as 120 000ms for the USOCL AT command. When USOCL was called and the response time was higher than the previously set time of 10 000ms the MKRNB 1500 freezes.

The changes were done to the NBClient.cpp's MODEM.waitForResponse. This fixed the issue of the MKRNB 1500 freezing while issuing the USOCL command in some cases.

There are more instances of MODEM.waitForResponse in other files, but it is unknown to me if these are calling the USOCL command. 